### PR TITLE
修改 settings.yaml

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -2687,7 +2687,6 @@ social:
       defaut: ""
       # default: "https://github.com/qinhua"
       placeholder: "github主页地址"
-      placeholder: "邮箱地址"
     gitee:
       name: gitee
       label: Gitee


### PR DESCRIPTION
修复主题设置=>社交=>Github占位符显示邮箱地址的错误内容,已修改为正确内容